### PR TITLE
Check return values when connecting to/creating a database

### DIFF
--- a/convert.cc
+++ b/convert.cc
@@ -56,8 +56,8 @@ int main(int argc, char* argv[]){
 	DB_ * x = new Libdb();
 	if (!x->connect_database(src)) {
 	// error is printed in the connect_database function
-	delete x;
-	return 1;
+		delete x;
+		return 1;
 	}
 	DB_ *b;
 	if (lmdb)
@@ -67,15 +67,19 @@ int main(int argc, char* argv[]){
 	if (!b->create_database(dst)) {
 		std::cerr<<"Failed to create destination database\n";
 		delete x;
+		x->close_db();
 		delete b;
 		return 1;
 	}
 	if (!b->fill_database(x)){
 		std::cerr<<"database filling failed\n";
+		x->close_db();
+		b->close_db();
 		delete x;
 		delete b;
 		return 1;
 	}
+	x->close_db();
 	b->close_db();
 	delete x;
 	delete b;

--- a/convert.cc
+++ b/convert.cc
@@ -54,18 +54,29 @@ int main(int argc, char* argv[]){
 
 
 	DB_ * x = new Libdb();
-	x->connect_database(src);
+	if (!x->connect_database(src)) {
+	// error is printed in the connect_database function
+	delete x;
+	return 1;
+	}
 	DB_ *b;
 	if (lmdb)
 		b = new LMDB_();
 	else
 		b = new GDBM_();
-	b->create_database(dst);
-	if (!b->fill_database(x)){
-		std::cerr<<"database filling failed\n";
+	if (!b->create_database(dst)) {
+		std::cerr<<"Failed to create destination database\n";
+		delete x;
+		delete b;
 		return 1;
 	}
-    	b->close_db();
+	if (!b->fill_database(x)){
+		std::cerr<<"database filling failed\n";
+		delete x;
+		delete b;
+		return 1;
+	}
+	b->close_db();
 	delete x;
 	delete b;
 	return 0;

--- a/convert.cc
+++ b/convert.cc
@@ -25,7 +25,7 @@ int main(int argc, char* argv[]){
         	{"src", required_argument, NULL, 's'},
         	{"lmdb", no_argument, NULL, 'l'},
         	{"help", no_argument, NULL, 'h'},
-		{0}
+        	{0, 0, 0, 0}
 	};
 	int option_index = 0;
 	while (1) {

--- a/convert.cc
+++ b/convert.cc
@@ -67,20 +67,15 @@ int main(int argc, char* argv[]){
 	if (!b->create_database(dst)) {
 		std::cerr<<"Failed to create destination database\n";
 		delete x;
-		x->close_db();
 		delete b;
 		return 1;
 	}
 	if (!b->fill_database(x)){
 		std::cerr<<"database filling failed\n";
-		x->close_db();
-		b->close_db();
 		delete x;
 		delete b;
 		return 1;
 	}
-	x->close_db();
-	b->close_db();
 	delete x;
 	delete b;
 	return 0;

--- a/convert_db.h
+++ b/convert_db.h
@@ -39,7 +39,7 @@ class DB_ {
 		virtual bool fill_database(DB_ * old_database);
 		virtual void close_db();
 		virtual DBC * get_database();
-    virtual ~DB_();
+		virtual ~DB_();
 };
 /*
  * Libdb class needs only open and read data from libdb database
@@ -54,6 +54,7 @@ class Libdb: public DB_ {
 		Libdb();
 		bool connect_database(std::string path);
 		DBC * get_database();
+		void close_db();
 };
 /*
  * GDBM class provides API for GDBM, allowes to open and create and fill gdbm database

--- a/convert_db.h
+++ b/convert_db.h
@@ -37,7 +37,7 @@ class DB_ {
 		virtual bool create_database(std::string name);
 		bool create_db();
 		virtual bool fill_database(DB_ * old_database);
-		virtual void close_db();
+		virtual void close_db() = 0;
 		virtual DBC * get_database();
 		virtual ~DB_();
 };
@@ -55,6 +55,7 @@ class Libdb: public DB_ {
 		bool connect_database(std::string path);
 		DBC * get_database();
 		void close_db();
+		~Libdb();
 };
 /*
  * GDBM class provides API for GDBM, allowes to open and create and fill gdbm database
@@ -71,6 +72,7 @@ class GDBM_: public DB_ {
 		bool create_database(std::string name);
 		bool fill_database(DB_ * old_database);
 		void close_db();
+		~GDBM_();
 };
 //https://github.com/LMDB/lmdb/blob/mdb.master/libraries/liblmdb/mtest2.c
 //further inspiration
@@ -88,5 +90,6 @@ class LMDB_: public DB_ {
 		bool create_database(std::string name);
 		bool fill_database(DB_ * old_database);
 		void close_db();
+		~LMDB_();
 };
 

--- a/convert_db.h
+++ b/convert_db.h
@@ -39,6 +39,7 @@ class DB_ {
 		virtual bool fill_database(DB_ * old_database);
 		virtual void close_db();
 		virtual DBC * get_database();
+    virtual ~DB_();
 };
 /*
  * Libdb class needs only open and read data from libdb database

--- a/db.cc
+++ b/db.cc
@@ -52,6 +52,11 @@ DBC * Libdb::get_database(){
 	return this->cursorp;
 }
 
+void Libdb::close_db() {
+	cursorp->close(cursorp);
+	db->close(db, 0);
+}
+
 GDBM_::GDBM_(){
 	database_type = DB_type::GDBM;
 }

--- a/db.cc
+++ b/db.cc
@@ -93,6 +93,8 @@ bool GDBM_::fill_database(DB_ * old_database){
 		if (status != 0)
 			return false;
 	}
+	free(data_db);
+	free(key_db);
 	return true;
 }
 

--- a/db.cc
+++ b/db.cc
@@ -1,10 +1,5 @@
 #include "convert_db.h"
 
-
-
-Libdb::Libdb(){
-	database_type = DB_type::LIBDB;
-};
 bool DB_::connect_database(std::string){
 	return false;
 }
@@ -24,6 +19,10 @@ void DB_::close_db(){}
 
 DB_::~DB_() {
 }
+
+Libdb::Libdb(){
+	database_type = DB_type::LIBDB;
+};
 
 bool Libdb::connect_database(std::string path){
 	DB * db;
@@ -55,6 +54,10 @@ DBC * Libdb::get_database(){
 void Libdb::close_db() {
 	cursorp->close(cursorp);
 	db->close(db, 0);
+}
+
+Libdb::~Libdb() {
+	close_db();
 }
 
 GDBM_::GDBM_(){
@@ -95,6 +98,10 @@ bool GDBM_::fill_database(DB_ * old_database){
 
 void GDBM_::close_db(){
 	gdbm_close(this->f);
+}
+
+GDBM_::~GDBM_() {
+	close_db();
 }
 
 LMDB_::LMDB_(){
@@ -170,4 +177,6 @@ void LMDB_::close_db(){
 	mdb_env_close(this->lmdb_database);
 }
 
-
+LMDB_::~LMDB_() {
+	close_db();
+}

--- a/db.cc
+++ b/db.cc
@@ -21,6 +21,10 @@ DBC * DB_::get_database() {
 	return NULL;
 }
 void DB_::close_db(){}
+
+DB_::~DB_() {
+}
+
 bool Libdb::connect_database(std::string path){
 	DB * db;
 	int status;


### PR DESCRIPTION
This fixes a bug where when establishing a connection to the src database fails (because it's invalid e.g. an empty file), the execution continues on creating the dst database and returning a 0 exit code.

The other 2 commits fix compiler warnings.